### PR TITLE
Filter out the /spec/ directory from simplcov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec/"
+end
 
 # Given that it is always loaded, you are encouraged to keep this file as
 # light-weight as possible. Requiring heavyweight dependencies from this file


### PR DESCRIPTION
# Why?
- Our code coverage tool (simplecov) was measuring the test coverage of our test code. Not only does that not make sense, it also skews our test coverage percentage.
# What Changed?
- Added `/spec/` filter to simple cov.
- We're at about 68% right now

| File | % covered Lines |
| --- | --- |
| lib/database/dbaccess_commands.rb | 32.26 % |
| lib/database/dbaccess_measurements.rb | 40.0 % |
| lib/database/dbaccess_logs.rb | 47.62 % |
| lib/database/dbaccess.rb | 78.75 % |
| lib/database/dbaccess_parameters.rb | 90.67 % |
| lib/database/dbaccess_refreshes.rb | 95.0 % |

everything in the `model` directory was at 100%
